### PR TITLE
Passing an array of keys, not a collection to the model

### DIFF
--- a/src/Engines/TNTSearchEngine.php
+++ b/src/Engines/TNTSearchEngine.php
@@ -149,7 +149,7 @@ class TNTSearchEngine extends Engine
             return Collection::make();
         }
 
-        $keys = collect($results['ids']);
+        $keys = collect($results['ids'])->values()->all();
         $models = $model->whereIn(
             $model->getKeyName(), $keys
         )->get()->keyBy($model->getKeyName());


### PR DESCRIPTION
Passing an array of keys, not a collection to the models whereIn function.
See Issue: https://github.com/teamtnt/laravel-scout-tntsearch-driver/issues/27