### PR TITLE
Accommodate Laravel installations making use of table prefixes

### DIFF
--- a/src/Engines/TNTSearchEngine.php
+++ b/src/Engines/TNTSearchEngine.php
@@ -185,7 +185,7 @@ class TNTSearchEngine extends Engine
             $indexer->disableOutput = true;
             $indexer->setPrimaryKey($model->getKeyName());
             $fields = implode(', ', array_keys($model->toSearchableArray()));
-            $indexer->query("SELECT {$model->getKeyName()}, $fields FROM {$model->getTable()} WHERE {$model->getKeyName()} = {$model->getKey()}");
+            $indexer->query("SELECT {$model->getKeyName()}, $fields FROM {$model->getTablePrefix()}{$model->getTable()} WHERE {$model->getKeyName()} = {$model->getKey()}");
             $indexer->run();
         }
     }


### PR DESCRIPTION
Added the getTablePrefix method call to the query to work with installations making use of table prefixes.