### PR TITLE
Add ability to set $asYouType property in config/scout.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ In your `config/scout.php` add:
         'max_expansions' => 50,
         'distance' => 2
     ],
+    'asYouType' => false,
 ],
 ```
 

--- a/src/TNTSearchScoutServiceProvider.php
+++ b/src/TNTSearchScoutServiceProvider.php
@@ -25,6 +25,7 @@ class TNTSearchScoutServiceProvider extends ServiceProvider
             $tnt->loadConfig($config);
             $tnt->setDatabaseHandle(app('db')->connection()->getPdo());
             $this->setFuzziness($tnt);
+            $this->setAsYouType($tnt);
 
             return new Engines\TNTSearchEngine($tnt);
         });
@@ -48,5 +49,12 @@ class TNTSearchScoutServiceProvider extends ServiceProvider
         $tnt->fuzzy_prefix_length = isset($prefix_length) ? $prefix_length : $tnt->fuzzy_prefix_length;
         $tnt->fuzzy_max_expansions = isset($max_expansions) ? $max_expansions : $tnt->fuzzy_max_expansions;
         $tnt->fuzzy_distance = isset($distance) ? $distance : $tnt->fuzzy_distance;
+    }
+
+    private function setAsYouType($tnt)
+    {
+        $asYouType = config('scout.tntsearch.asYouType');
+
+        $tnt->asYouType = isset($asYouType) ? $asYouType : $tnt->asYouType;
     }
 }


### PR DESCRIPTION
Being able to set the `$asYouType` property in the `config/scout.php` file was requested in #49. 

This request adds this feature with a `setAsYouType()` method. It is based on the `setFuzziness()` method, which also sets a property of a `TNTSearch` instance from the config file.

This is my first real pull request so apologies in advance if I've left out any information and criticism is greatly appreciated 😃 