### PR TITLE
Ignore non-existant model when results are out of sync

### DIFF
--- a/src/Engines/TNTSearchEngine.php
+++ b/src/Engines/TNTSearchEngine.php
@@ -159,7 +159,9 @@ class TNTSearchEngine extends Engine
         )->get()->keyBy($model->getKeyName());
 
         return collect($results['ids'])->map(function ($hit) use ($models) {
-            return $models[$hit];
+            return isset($models[$hit]) ? $models[$hit] : null;
+        })->filter(function ($model) {
+            return !is_null($model);
         });
     }
 

--- a/src/Engines/TNTSearchEngine.php
+++ b/src/Engines/TNTSearchEngine.php
@@ -159,7 +159,7 @@ class TNTSearchEngine extends Engine
         )->get()->keyBy($model->getKeyName());
 
         return collect($results['ids'])->map(function ($hit) use ($models) {
-            return isset($models[$hit]) ? $models[$hit] : null;
+            return $models->has($hit) ? $models[$hit] : null;
         })->filter(function ($model) {
             return !is_null($model);
         });


### PR DESCRIPTION
When not deleting indexes on the fly (for example in queue), then sometimes results were out of sync and ErrorException was thrown:

> Undefined offset: [$id]

This change makes TNTSearch to ignore these results

I found same fix here.
https://github.com/teamtnt/laravel-scout-tntsearch-driver/pull/38

I assume it wasn't merged because of incorrect whitespaces?