### PR TITLE
Make private functions protected

### DIFF
--- a/src/TNTSearchScoutServiceProvider.php
+++ b/src/TNTSearchScoutServiceProvider.php
@@ -37,7 +37,7 @@ class TNTSearchScoutServiceProvider extends ServiceProvider
         }
     }
 
-    private function setFuzziness($tnt)
+    protected function setFuzziness($tnt)
     {
         $fuzziness = config('scout.tntsearch.fuzziness');
         $prefix_length = config('scout.tntsearch.fuzzy.prefix_length');
@@ -51,7 +51,7 @@ class TNTSearchScoutServiceProvider extends ServiceProvider
         $tnt->fuzzy_distance = isset($distance) ? $distance : $tnt->fuzzy_distance;
     }
 
-    private function setAsYouType($tnt)
+    protected function setAsYouType($tnt)
     {
         $asYouType = config('scout.tntsearch.asYouType');
 


### PR DESCRIPTION
This allows extending of the service provider class without having to copy everything over wholesale.
(I'm extending the service provider class to  load my extended version of the TNTSearch class that slightly alters the search query to use `LIKE '%xxx%'` instead of `LIKE 'xxx%'.)