### PR TITLE
Exclude empty searchable arrays from indexing

### DIFF
--- a/src/Engines/TNTSearchEngine.php
+++ b/src/Engines/TNTSearchEngine.php
@@ -46,10 +46,16 @@ class TNTSearchEngine extends Engine
 
         $index->indexBeginTransaction();
         $models->each(function ($model) use ($index) {
+            $array = $model->toSearchableArray();
+
+            if (empty($array)) {
+                return;
+            }
+
             if ($model->getKey()) {
-                $index->update($model->getKey(), $model->toSearchableArray());
+                $index->update($model->getKey(), $array);
             } else {
-                $index->insert($model->toSearchableArray());
+                $index->insert($array);
             }
         });
         $index->indexEndTransaction();


### PR DESCRIPTION
If a model's ```toSearchableArray()``` method returns an empty array, it should not be indexed.