### PR TITLE
Add support to multiple connections

### DIFF
--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -34,12 +34,12 @@ class ImportCommand extends Command
         $class = $this->argument('model');
 
         $model = new $class();
-        $tnt = new TNTSearch();
-        $driver = config('database.default');
+        $tnt = new TNTSearch();        
+        $driver = $model->getConnectionName() ?: config('database.default');
         $config = config('scout.tntsearch') + config("database.connections.$driver");
 
         $tnt->loadConfig($config);
-        $tnt->setDatabaseHandle(app('db')->connection()->getPdo());
+        $tnt->setDatabaseHandle(app('db')->connection($driver)->getPdo());
 
         $indexer = $tnt->createIndex($model->searchableAs().'.index');
         $indexer->setPrimaryKey($model->getKeyName());


### PR DESCRIPTION
Currently, the TNT Search command looks for the default database configuration. However, there may be more than one connection in the project.

With this small change, the command starts to look for the connection configuration first in the model, and it starts to support multiple connections.