### PR TITLE
Only select columns that exist in the database

### DIFF
--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -43,7 +43,11 @@ class ImportCommand extends Command
 
         $indexer = $tnt->createIndex($model->searchableAs().'.index');
         $indexer->setPrimaryKey($model->getKeyName());
-        $fields = implode(', ', array_keys($model->toSearchableArray()));
+
+        $availableColumns = \Schema::getColumnListing($model->getTable());
+        $desiredColumns = array_keys($model->toSearchableArray());
+
+        $fields = implode(', ', array_intersect($desiredColumns, $availableColumns));
 
         $query = "{$model->getKeyName()}, $fields";
 


### PR DESCRIPTION
I have a model that has a few `$appends` attributes that do not exist in the database, that I need to serve in JSON responses in my application.

When Laravel Scout grabs the keys of the results of the `toArray()` method in its `Searchable` trait it also grabs all of the accessors defined in the `$appends` field.
https://github.com/laravel/scout/blob/3.0/src/Searchable.php#L199-L207

For example, I have an `Article` model that has an accessor to generate a field named "published_at_atom." This field does not exist in my database, only on the model.
In this packages current state, this is what I would get if I tried to run the `tntsearch:import` command:
![image](https://user-images.githubusercontent.com/8620392/34047312-78d81df6-e175-11e7-90e3-d1a7e9489c38.png)

All this proposed change does is retrieve the available columns from the models table, and intersect that with the desired columns from the `toSearchableArray()` method, and selecting only those.

This way this package does not attempt to select nonexistant columns.