### PR TITLE
Updated the README with recommendation to ignore .index files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,12 @@ In your `config/scout.php` add:
     'searchBoolean' => env('TNTSEARCH_BOOLEAN', false),
 ],
 ```
+To prevent your search indexes being commited to your project repository,
+add the following line to your `.gitignore` file.
 
-The `asYouType` option can be set per model basis, see example bellow
+```/storage/*.index```
+
+The `asYouType` option can be set per model basis, see the example below.
 
 ## Usage
 


### PR DESCRIPTION
Hi all,

When using this package I almost accidentally commited my index files to my repo, I can't imagine that being a good idea ever (and a security risk for open-source projects). Therefore, I added a recommendation to add storage/*.index files to the .gitignore file, as an extra security measure to prevent this from happening. 

I also fixed a spelling mistake that was underneath my added text.