### PR TITLE
solves issue #197

### DIFF
--- a/src/Engines/TNTSearchEngine.php
+++ b/src/Engines/TNTSearchEngine.php
@@ -18,11 +18,6 @@ class TNTSearchEngine extends Engine
     protected $tnt;
 
     /**
-     * @var Builder
-     */
-    protected $builder;
-
-    /**
      * Used to query database with given constraints.
      *
      * @var Builder
@@ -223,10 +218,6 @@ class TNTSearchEngine extends Engine
      */
     public function getBuilder($model)
     {
-        if (isset($this->query)) {
-            return $this->query;
-        }
-
         // get query as given constraint or create a new query
         $builder = isset($this->builder->constraints) ? $this->builder->constraints : $model->newQuery();
 
@@ -236,7 +227,7 @@ class TNTSearchEngine extends Engine
 
         $builder = $this->applyOrders($builder);
 
-        return $this->query = $builder;
+	return $builder;
     }
 
     /**


### PR DESCRIPTION
breaks with commit https://github.com/teamtnt/laravel-scout-tntsearch-driver/commit/697094ea4b460766eaa6d58e05649e641e20883b

temporary fix is downgrading to:
 "laravel/scout": "^4.0",
"teamtnt/laravel-scout-tntsearch-driver": "3.0.7",

laravel/scout has to be required explicitly on this version since we get incompatible map method exception on version 5.*+