### PR TITLE
Update paginate method in TNTSearchEngine.php

### DIFF
--- a/src/Engines/TNTSearchEngine.php
+++ b/src/Engines/TNTSearchEngine.php
@@ -127,7 +127,7 @@ class TNTSearchEngine extends Engine
         if (array_key_exists($page - 1, $chunks)) {
             $results['ids'] = $chunks[$page - 1];
         } else {
-            $results['ids'] = end($chunks);
+            $results['ids'] = [];
         }
 
         return $results;


### PR DESCRIPTION
Return empty array for empty results in place of end(chunks). Previously caused the pagination to return false values for empty results.