### PR TITLE
fix: use model connection

### DIFF
--- a/src/Engines/TNTSearchEngine.php
+++ b/src/Engines/TNTSearchEngine.php
@@ -288,7 +288,7 @@ class TNTSearchEngine extends Engine
 
         $discardIds = $builder->model->newQuery()
             ->select($qualifiedKeyName)
-            ->leftJoin(DB::raw('('.$sub->getQuery()->toSql().') as '. DB::connection()->getTablePrefix() .'sub'), $subQualifiedKeyName, '=', $qualifiedKeyName)
+            ->leftJoin(DB::raw('('.$sub->getQuery()->toSql().') as '. $builder->model->getConnection()->getTablePrefix() .'sub'), $subQualifiedKeyName, '=', $qualifiedKeyName)
             ->addBinding($sub->getQuery()->getBindings(), 'join')
             ->whereIn($qualifiedKeyName, $searchResults)
             ->whereNull($subQualifiedKeyName)


### PR DESCRIPTION
this will cause issue when model using another connection like this:
https://laravel.com/docs/5.8/eloquent
```php
<?php

namespace App;

use Illuminate\Database\Eloquent\Model;

class Flight extends Model
{
    /**
     * The connection name for the model.
     *
     * @var string
     */
    protected $connection = 'connection-name';
}
```

Fix:
- use `model->getConnection()` instead of `DB::connection`