### PR TITLE
[PoC] Add GeoSearch Index and search

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,16 @@ In your `config/scout.php` add:
     ],
     'asYouType' => false,
     'searchBoolean' => env('TNTSEARCH_BOOLEAN', false),
+    'geoIndex' => env('TNTSEARCH_GEOINDEX', false),
 ],
 ```
 To prevent your search indexes being commited to your project repository,
 add the following line to your `.gitignore` file.
 
-```/storage/*.index```
+```
+/storage/*.index
+/storage/*.geoindex
+```
 
 The `asYouType` option can be set per model basis, see the example below.
 

--- a/src/TNTSearchScoutServiceProvider.php
+++ b/src/TNTSearchScoutServiceProvider.php
@@ -1,5 +1,6 @@
 <?php namespace TeamTNT\Scout;
 
+use TeamTNT\TNTSearch\TNTGeoSearch;
 use TeamTNT\TNTSearch\TNTSearch;
 use Laravel\Scout\EngineManager;
 use Laravel\Scout\Builder;
@@ -28,7 +29,15 @@ class TNTSearchScoutServiceProvider extends ServiceProvider
             $this->setFuzziness($tnt);
             $this->setAsYouType($tnt);
 
-            return new TNTSearchEngine($tnt);
+            $geotnt = null;
+            if (!empty($config['geoIndex'])) {
+                $geotnt = new TNTGeoSearch();
+
+                $geotnt->loadConfig($config);
+                $geotnt->setDatabaseHandle(app('db')->connection()->getPdo());
+            }
+
+            return new TNTSearchEngine($tnt, $geotnt);
         });
 
         if ($this->app->runningInConsole()) {

--- a/tests/TNTSearchEngineTest.php
+++ b/tests/TNTSearchEngineTest.php
@@ -29,7 +29,36 @@ class TNTSearchEngineTest extends PHPUnit_Framework_TestCase
         $index->shouldReceive('update');
         $index->shouldReceive('indexEndTransaction');
 
-        $engine = new TNTSearchEngine($client);
+        $geoClient = Mockery::mock('TeamTNT\TNTSearch\TNTGeoSearch');
+
+        $config = [
+            'storage'  => '/',
+            'fuzziness' => false,
+            'fuzzy' => [
+                'prefix_length' => 2,
+                'max_expansions' => 50,
+                'distance' => 2
+            ],
+            'asYouType' => false,
+            'searchBoolean' => false,
+        ];
+
+        $geoClient->shouldReceive('getIndex')
+            ->andReturn($geoIndex = Mockery::mock('TeamTNT\TNTSearch\Indexer\TNTGeoIndexer'))
+            ->andSet('config', $config);
+        $geoIndex->shouldReceive('loadConfig');
+        $geoIndex->shouldReceive('createIndex')
+            ->with('table.geoindex');
+        $geoIndex->shouldReceive('setDatabaseHandle');
+        $geoIndex->shouldReceive('setPrimaryKey');
+        $geoClient->shouldReceive('selectIndex');
+        $geoIndex->shouldReceive('indexBeginTransaction');
+        $geoIndex->shouldReceive('prepareAndExecuteStatement');
+        $geoIndex->shouldReceive('insert');
+        $geoIndex->shouldReceive('indexEndTransaction');
+
+
+        $engine = new TNTSearchEngine($client, $geoClient);
         $engine->update(Collection::make([new TNTSearchEngineTestModel()]));
     }
 }


### PR DESCRIPTION
Proof of the concept of creating a GeoSearch Index.
The index is maintained at the same time as the main index.
To call up the GeoSearch Index search:
```php
// $builder->query should be passed as an array
$params = [
  'locaton' => [
    'longitude' => $lng, // float
    'latitude' => $lat, // float
  ],
  'distance' => $distance, // float
  'limit' => $limit, // integer optional
];

Address::search($params);
```

Fix #170 #235