### PR TITLE
Add Scout 8 to dependencies (Laravel 7)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": ">=7.1",
         "teamtnt/tntsearch": "2.*",
-        "laravel/scout": "7.*",
+        "laravel/scout": "7.*|^8.0",
         "illuminate/bus": "~5.4|^6.0|^7.0",
         "illuminate/contracts": "~5.4|^6.0|^7.0",
         "illuminate/database": "~5.4|^6.0|^7.0",


### PR DESCRIPTION
A new major version of Scout was released with Laravel 7.

This PR adds it as a possible dependency to allow Laravel 7 users to install.