### PR TITLE
Honor the intended collection for the model

### DIFF
--- a/src/Engines/TNTSearchEngine.php
+++ b/src/Engines/TNTSearchEngine.php
@@ -199,7 +199,7 @@ class TNTSearchEngine extends Engine
         }
 
         // sort models by tnt search result set
-        return collect($results['ids'])->map(function ($hit) use ($models) {
+        return $model->newCollection($results['ids'])->map(function ($hit) use ($models) {
             if (isset($models[$hit])) {
                 return $models[$hit];
             }


### PR DESCRIPTION
When a user overrides the model's default collection, we are not honoring that intent.

With this change, the collection instance is fetched from the model.