### PR TITLE
Fixed commands scout:status and scout:import

### DIFF
--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -43,13 +43,18 @@ class ImportCommand extends Command
         $tnt->loadConfig($config);
         $tnt->setDatabaseHandle($db->getPdo());
 
+        if(!$model->count()) {
+            $this->info('Nothing to import.');
+            exit(0);
+        }
+        
         $indexer = $tnt->createIndex($model->searchableAs().'.index');
         $indexer->setPrimaryKey($model->getKeyName());
 
         $availableColumns = Schema::connection($driver)->getColumnListing($model->getTable());
         $desiredColumns = array_keys($model->toSearchableArray());
 
-        $fields = array_intersect($desiredColumns, $availableColumns);
+        $desiredColumns = array_keys($model->first()->toSearchableArray());
 
         $query = $db->table($model->getTable());
 

--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -52,9 +52,9 @@ class ImportCommand extends Command
         $indexer->setPrimaryKey($model->getKeyName());
 
         $availableColumns = Schema::connection($driver)->getColumnListing($model->getTable());
-        $desiredColumns = array_keys($model->toSearchableArray());
-
         $desiredColumns = array_keys($model->first()->toSearchableArray());
+
+        $fields = array_intersect($desiredColumns, $availableColumns);
 
         $query = $db->table($model->getTable());
 

--- a/src/Console/StatusCommand.php
+++ b/src/Console/StatusCommand.php
@@ -79,7 +79,7 @@ class StatusCommand extends Command
         }
 
         $this->output->progressFinish();
-        $this->output->table($headers, $rows, $tableStyle = 'default', $columnStyles = []);
+        $this->output->table($headers, $rows);
     }
 
     /**

--- a/src/Console/StatusCommand.php
+++ b/src/Console/StatusCommand.php
@@ -63,10 +63,10 @@ class StatusCommand extends Command
                 $rowsIndexed = 0;
             }
 
-            $indexedColumns = implode(",", array_keys($model->toSearchableArray()));
-
             $rowsTotal = $model->count();
             $recordsDifference = $rowsTotal - $rowsIndexed;
+
+            $indexedColumns = $rowsTotal ? implode(",", array_keys($model->first()->toSearchableArray())) : '';
 
             if($recordsDifference == 0) {
                 $recordsDifference = '<fg=green>Synchronized</>';


### PR DESCRIPTION
At the moment the indexed columns return empty array when you run scout:status

With this update it's shown.

It's only missing to exclude primary key if it's not indexed, but there is no way to access variable `TNTIndexer::$excludePrimaryKey` for check if it's excluded or not.