### PR TITLE
Results can be null

### DIFF
--- a/src/Engines/TNTSearchEngine.php
+++ b/src/Engines/TNTSearchEngine.php
@@ -193,7 +193,7 @@ class TNTSearchEngine extends Engine
      */
     public function map(Builder $builder, $results, $model)
     {
-        if (is_null($results['ids']) || count($results['ids']) === 0) {
+        if (empty($results['ids'])) {
             return Collection::make();
         }
 


### PR DESCRIPTION
Proof it works:
https://3v4l.org/MW8q8

In the current situation it will error because of a reference to an array index on null. 
This fixes this issue.