### PR TITLE
fix: broken functionality if soft_delete is set to true

### DIFF
--- a/src/Engines/TNTSearchEngine.php
+++ b/src/Engines/TNTSearchEngine.php
@@ -352,7 +352,7 @@ class TNTSearchEngine extends Engine
          *
          * When no __soft_deleted statement is given return all entries
          */
-        if (!in_array('__soft_deleted', $this->builder->wheres)) {
+        if (!array_key_exists('__soft_deleted', $this->builder->wheres)) {
             return $builder->withTrashed();
         }
 


### PR DESCRIPTION
This commit fixes the broken functionality ("undefined column __soft_deleted") when `soft_delete` is set to true in `scout.php` config. The reason for this is the change in behavior of `in_array` from PHP 7 to 8. Specifically, in PHP 7, `in_array($aKeyThatExists, $singleDimensionalArray)` returns TRUE, but the same call in PHP 8 would return FALSE): https://3v4l.org/JRUZs.

This fixes #318.