### PR TITLE
Reload Configuration before search

### DIFF
--- a/src/Engines/TNTSearchEngine.php
+++ b/src/Engines/TNTSearchEngine.php
@@ -153,6 +153,11 @@ class TNTSearchEngine extends Engine
      */
     protected function performSearch(Builder $builder, array $options = [])
     {
+        $driver = config('database.default');
+        $config = config('scout.tntsearch') + config("database.connections.{$driver}");
+
+        $this->tnt->loadConfig($config);
+        
         $index = $builder->index ?: $builder->model->searchableAs();
         $limit = $builder->limit ?: 10000;
         $this->tnt->selectIndex("{$index}.index");


### PR DESCRIPTION
I have a situation similar to #169 where I need to run a boolean search followed by a regular search. After programmatically changing the config, the settings were not being applied in the second search. 

```
                //.env contains
                //SCOUT_DRIVER=tntsearch
                //SCOUT_QUEUE=true
                //TNTSEARCH_BOOLEAN=true

                $illustrations = Illustration::search($search_string)->get(); //Boolean as expected
                $ids = $illustrations->pluck('id');
                $rel_constraints = new Illustration;
                $rel_constraints = $rel_constraints->whereIn('id',$ids);
                config(['scout.tntsearch.searchBoolean' => false]);
                $rel_illustrations = Illustration::search($search_string)->constrain($rel_constraints)->get(); //Still Boolean
```

I may be mistaken about this, but it seems $tnt->loadConfig($config); is only run once in TNTSearchScoutServiceProvider boot(), so changing the config elsewhere never gets applied.