### PR TITLE
StatusCommand checks trait recursively

### DIFF
--- a/src/Console/StatusCommand.php
+++ b/src/Console/StatusCommand.php
@@ -141,7 +141,7 @@ class StatusCommand extends Command
     private function isSearchableModel($trait)
     {
         return function ($className) use ($trait) {
-            $traits = class_uses($className);
+            $traits = class_uses_recursive($className);
 
             return isset($traits[$trait]);
         };


### PR DESCRIPTION
This change will allow the StatusCommand to find Models that uses the trait `Laravel\Scout\Searchable` even if imported from another trait.