### PR TITLE
Add possibility to order different model searches by score

### DIFF
--- a/src/Engines/TNTSearchEngine.php
+++ b/src/Engines/TNTSearchEngine.php
@@ -218,9 +218,9 @@ class TNTSearchEngine extends Engine
         }
 
         // sort models by tnt search result set
-        return $model->newCollection(collect($results['ids'])->map(function ($hit) use ($models) {
+        return $model->newCollection(collect($results['ids'])->map(function ($hit, $key) use ($models, $results) {
             if (isset($models[$hit])) {
-                return $models[$hit];
+                return $models[$hit]->setAttribute('__tntSearchScore__', $results['docScores'][$hit]);
             }
         })->filter()->all());
     }

--- a/src/Engines/TNTSearchEngine.php
+++ b/src/Engines/TNTSearchEngine.php
@@ -218,11 +218,11 @@ class TNTSearchEngine extends Engine
         }
 
         // sort models by tnt search result set
-        return $model->newCollection($results['ids'])->map(function ($hit) use ($models) {
+        return $model->newCollection(collect($results['ids'])->map(function ($hit) use ($models) {
             if (isset($models[$hit])) {
                 return $models[$hit];
             }
-        })->filter()->values();
+        })->filter()->all());
     }
 
     /**

--- a/src/Engines/TNTSearchEngine.php
+++ b/src/Engines/TNTSearchEngine.php
@@ -218,11 +218,11 @@ class TNTSearchEngine extends Engine
         }
 
         // sort models by tnt search result set
-        return $model->newCollection(collect($results['ids'])->map(function ($hit, $key) use ($models, $results) {
+        return $model->newCollection($results['ids'])->map(function ($hit, $key) use ($models, $results) {
             if (isset($models[$hit])) {
                 return $models[$hit]->setAttribute('__tntSearchScore__', $results['docScores'][$hit]);
             }
-        })->filter()->all());
+        })->filter()->values();
     }
 
     /**


### PR DESCRIPTION
In order to make sure, that https://github.com/teamtnt/tntsearch/issues/55 will be possible, I created a PR on the tntSearch repo https://github.com/teamtnt/tntsearch/pull/273. To complete the cycle, it'd be nice to be able to add __tntSearchScore__ into the models attributes, to be able to order multiple models by their scores.

# Will also affect 
https://github.com/teamtnt/laravel-scout-tntsearch-driver/issues/222

