### PR TITLE
Allow the status command with no model given to read from config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 .DS_Store
 Thumbs.db
 .idea
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ Or you can pass a searchable model argument:
 
 `php artisan scout:status "App\Models\Post"`
 
+If your models are not in the default location `app` or one of its subdirectories, you may set the `modelPath` option
+```php
+// config/scout.php
+'tntsearch' => [
+    // ...
+    'modelPath' => 'models',
+],
+```
+
 ![Image of Scout Status Command](https://teamtnt.github.io/img/scout_status_single_new.png)
 
 ## Constraints

--- a/src/Console/StatusCommand.php
+++ b/src/Console/StatusCommand.php
@@ -4,11 +4,9 @@ namespace TeamTNT\Scout\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Events\Dispatcher;
-use TeamTNT\TNTSearch\Exceptions\IndexNotFoundException;
-use TeamTNT\TNTSearch\Indexer\TNTIndexer;
-use TeamTNT\TNTSearch\TNTSearch;
-use Illuminate\Support\Facades\Schema;
 use Symfony\Component\Finder\Finder;
+use TeamTNT\TNTSearch\Exceptions\IndexNotFoundException;
+use TeamTNT\TNTSearch\TNTSearch;
 
 class StatusCommand extends Command
 {
@@ -89,7 +87,9 @@ class StatusCommand extends Command
     {
 
         if (self::$declaredClasses === null) {
-            $configFiles = Finder::create()->files()->name('*.php')->notName('*.blade.php')->in(app()->path());
+            $configFiles = Finder::create()->files()
+                ->name('*.php')->notName('*.blade.php')
+                ->in(config('scout.tntsearch.modelPath', app()->path()));
 
             foreach ($configFiles->files() as $file) {
                 try {


### PR DESCRIPTION
We are using the `nwidart/laravel-modules` package and would like to be able to see the status of indexed models, but they are not located in the default location. We can view one at a time by passing the class string, but the "all" status with no model always uses `app` as its target.

This PR allows the default location to be overridden with a config option, while still defaulting to the current behavior