### PR TITLE
fix: fix dynamic properties deprecation notices, fixes #359

### DIFF
--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -4,7 +4,7 @@ namespace TeamTNT\Scout\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Events\Dispatcher;
-use TeamTNT\TNTSearch\TNTSearch;
+use TeamTNT\Scout\ExtendedTNTSearch as TNTSearch;
 use Illuminate\Support\Facades\Schema;
 
 class ImportCommand extends Command
@@ -43,12 +43,12 @@ class ImportCommand extends Command
         $tnt->loadConfig($config);
         $tnt->setDatabaseHandle($db->getPdo());
 
-        if(!$model->count()) {
+        if (!$model->count()) {
             $this->info('Nothing to import.');
             exit(0);
         }
-        
-        $indexer = $tnt->createIndex($model->searchableAs().'.index');
+
+        $indexer = $tnt->createIndex($model->searchableAs() . '.index');
         $indexer->setPrimaryKey($model->getKeyName());
 
         $availableColumns = Schema::connection($driver)->getColumnListing($model->getTable());
@@ -74,6 +74,6 @@ class ImportCommand extends Command
         $indexer->query($sql);
 
         $indexer->run();
-        $this->info('All ['.$class.'] records have been imported.');
+        $this->info('All [' . $class . '] records have been imported.');
     }
 }

--- a/src/Console/StatusCommand.php
+++ b/src/Console/StatusCommand.php
@@ -6,7 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Contracts\Events\Dispatcher;
 use Symfony\Component\Finder\Finder;
 use TeamTNT\TNTSearch\Exceptions\IndexNotFoundException;
-use TeamTNT\TNTSearch\TNTSearch;
+use TeamTNT\Scout\ExtendedTNTSearch as TNTSearch;
 
 class StatusCommand extends Command
 {
@@ -42,7 +42,7 @@ class StatusCommand extends Command
 
         $searchableModels = $this->getSearchableModels();
 
-        $this->output->text('🔎 Analysing information from: <info>['.implode(',', $searchableModels).']</info>');
+        $this->output->text('🔎 Analysing information from: <info>[' . implode(',', $searchableModels) . ']</info>');
         $this->output->newLine();
         $this->output->progressStart(count($searchableModels));
 
@@ -52,7 +52,7 @@ class StatusCommand extends Command
             $model = new $class();
 
             $tnt = $this->loadTNTEngine($model);
-            $indexName = $model->searchableAs().'.index';
+            $indexName = $model->searchableAs() . '.index';
 
             try {
                 $tnt->selectIndex($indexName);
@@ -66,14 +66,13 @@ class StatusCommand extends Command
 
             $indexedColumns = $rowsTotal ? implode(",", array_keys($model->first()->toSearchableArray())) : '';
 
-            if($recordsDifference == 0) {
+            if ($recordsDifference == 0) {
                 $recordsDifference = '<fg=green>Synchronized</>';
             } else {
                 $recordsDifference = "<fg=red>$recordsDifference</>";
             }
 
             array_push($rows, [$class, $indexName, $indexedColumns, $rowsIndexed, $rowsTotal, $recordsDifference]);
-
         }
 
         $this->output->progressFinish();

--- a/src/Engines/ExtendedScoutBuilder.php
+++ b/src/Engines/ExtendedScoutBuilder.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace TeamTNT\Scout\Engines;
+
+use Laravel\Scout\Builder;
+
+class ExtendedScoutBuilder extends Builder
+{
+    public $constraints;
+}

--- a/src/Engines/TNTSearchEngine.php
+++ b/src/Engines/TNTSearchEngine.php
@@ -9,10 +9,11 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use InvalidArgumentException;
 use Laravel\Scout\Builder;
+use TeamTNT\Scout\Engines\ExtendedScoutBuilder;
 use Laravel\Scout\Engines\Engine;
 use TeamTNT\Scout\Events\SearchPerformed;
 use TeamTNT\TNTSearch\Exceptions\IndexNotFoundException;
-use TeamTNT\TNTSearch\TNTSearch;
+use TeamTNT\Scout\ExtendedTNTSearch as TNTSearch;
 
 class TNTSearchEngine extends Engine
 {
@@ -24,7 +25,7 @@ class TNTSearchEngine extends Engine
     protected $tnt;
 
     /**
-     * @var Builder
+     * @var ExtendedScoutBuilder
      */
     protected $builder;
 
@@ -176,7 +177,6 @@ class TNTSearchEngine extends Engine
             $res = $this->tnt->searchBoolean($builder->query, $limit);
             event(new SearchPerformed($builder, $res, true));
             return $res;
-
         } else {
             $res = $this->tnt->search($builder->query, $limit);
             event(new SearchPerformed($builder, $res));
@@ -207,7 +207,8 @@ class TNTSearchEngine extends Engine
         }
 
         $models = $builder->whereIn(
-            $model->getQualifiedKeyName(), $keys
+            $model->getQualifiedKeyName(),
+            $keys
         )->get()->keyBy($model->getKeyName());
 
         // sort models by user choice
@@ -250,7 +251,8 @@ class TNTSearchEngine extends Engine
         }
 
         $models = $builder->whereIn(
-            $model->getQualifiedKeyName(), $keys
+            $model->getQualifiedKeyName(),
+            $keys
         )->get()->keyBy($model->getKeyName());
 
         // sort models by user choice
@@ -351,7 +353,8 @@ class TNTSearchEngine extends Engine
         $subQualifiedKeyName = 'sub.' . $builder->model->getKeyName(); // sub.id
 
         $sub = $this->getBuilder($builder->model)->whereIn(
-            $qualifiedKeyName, $searchResults
+            $qualifiedKeyName,
+            $searchResults
         ); // sub query for left join
 
         $discardIds = $builder->model->newQuery()

--- a/src/Events/SearchPerformed.php
+++ b/src/Events/SearchPerformed.php
@@ -4,6 +4,15 @@ namespace TeamTNT\Scout\Events;
 
 class SearchPerformed
 {
+    public $query;
+    public $isBooleanSearch;
+    public $indexName;
+    public $model;
+    public $ids;
+    public $execution_time;
+    public $driver;
+    public $hits;
+
     public function __construct($builder, $results, $isBooleanSearch = false)
     {
         $this->query           = $builder->query;

--- a/src/ExtendedTNTSearch.php
+++ b/src/ExtendedTNTSearch.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace TeamTNT\Scout;
+
+use TeamTNT\TNTSearch\TNTSearch;
+
+class ExtendedTNTSearch extends TNTSearch
+{
+    public $engine;
+    public $maxDocs;
+    public $asYouType;
+}

--- a/src/TNTSearchScoutServiceProvider.php
+++ b/src/TNTSearchScoutServiceProvider.php
@@ -1,4 +1,6 @@
-<?php namespace TeamTNT\Scout;
+<?php
+
+namespace TeamTNT\Scout;
 
 use Illuminate\Support\ServiceProvider;
 use Laravel\Scout\Builder;
@@ -6,10 +8,12 @@ use Laravel\Scout\EngineManager;
 use TeamTNT\Scout\Console\ImportCommand;
 use TeamTNT\Scout\Console\StatusCommand;
 use TeamTNT\Scout\Engines\TNTSearchEngine;
-use TeamTNT\TNTSearch\TNTSearch;
+use TeamTNT\Scout\ExtendedTNTSearch as TNTSearch;
 
 class TNTSearchScoutServiceProvider extends ServiceProvider
 {
+    public $constraints;
+
     /**
      * Bootstrap any application services.
      *

--- a/tests/TNTSearchEngineTest.php
+++ b/tests/TNTSearchEngineTest.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use TeamTNT\Scout\Engines\TNTSearchEngine;
-use TeamTNT\TNTSearch\TNTSearch;
+use TeamTNT\Scout\ExtendedTNTSearch as TNTSearch;
 
 class TNTSearchEngineTest extends TestCase
 {
@@ -20,11 +20,10 @@ class TNTSearchEngineTest extends TestCase
         $engine = new TeamTNT\Scout\Engines\TNTSearchEngine($tnt);
 
         $engine->addFilter("query_expansion", function ($query, $model) {
-            if ($query == "test" && $model == "TeamTNT\TNTSearch\TNTSearch") {
-                return "modified-".$query;
+            if ($query == "test" && $model == "TeamTNT\Scout\ExtendedTNTSearch") {
+                return "modified-" . $query;
             }
             return $query;
-
         });
 
         $query  = $engine->applyFilters('query_expansion', "test", TNTSearch::class);


### PR DESCRIPTION
Notes (mainly because there are no docs or tests in the codebase):
- Properties in `TeamTNT\Scout\Events\SearchPerformed` are a permissive `public`.
- Don't know how to test for the `$constraints` properties.