### PR TITLE
Fix Scout 11 wheres format compatibility

### DIFF
--- a/src/Engines/TNTSearchEngine.php
+++ b/src/Engines/TNTSearchEngine.php
@@ -399,31 +399,51 @@ class TNTSearchEngine extends Engine
         // does not show soft deleted items when trait is attached to model and
         // config('scout.soft_delete') is false
         if (!$this->usesSoftDelete($model) || !config('scout.soft_delete', true)) {
-            unset($this->builder->wheres['__soft_deleted']);
+            $this->removeSoftDeleteWhere();
             return $builder;
         }
+
+        $softDeleteWhere = $this->findSoftDeleteWhere();
 
         /**
          * Use standard behaviour of Laravel Scout builder class to support soft deletes.
          *
          * When no __soft_deleted statement is given return all entries
          */
-        if (!array_key_exists('__soft_deleted', $this->builder->wheres)) {
+        if ($softDeleteWhere === null) {
             return $builder->withTrashed();
         }
 
         /**
          * When __soft_deleted is 1 then return only soft deleted entries
          */
-        if ($this->builder->wheres['__soft_deleted']) {
+        if ($softDeleteWhere['value']) {
             $builder = $builder->onlyTrashed();
         }
 
         /**
          * Returns all undeleted entries, default behaviour
          */
-        unset($this->builder->wheres['__soft_deleted']);
+        $this->removeSoftDeleteWhere();
         return $builder;
+    }
+
+    private function findSoftDeleteWhere()
+    {
+        foreach ($this->builder->wheres as $where) {
+            if (is_array($where) && isset($where['field']) && $where['field'] === '__soft_deleted') {
+                return $where;
+            }
+        }
+        return null;
+    }
+
+    private function removeSoftDeleteWhere()
+    {
+        $this->builder->wheres = array_values(array_filter(
+            $this->builder->wheres,
+            fn ($where) => !is_array($where) || !isset($where['field']) || $where['field'] !== '__soft_deleted'
+        ));
     }
 
     /**
@@ -434,14 +454,13 @@ class TNTSearchEngine extends Engine
      */
     private function applyWheres($builder)
     {
-        // iterate over given where clauses
-        return collect($this->builder->wheres)->map(function ($value, $key) {
-            // for reduce function combine key and value into array
-            return [$key, $value];
-        })->reduce(function ($builder, $where) {
-            // separate key, value again
-            list($key, $value) = $where;
-            return $builder->where($key, $value);
+        // iterate over given where clauses (Scout 11+ format: array of arrays with field/operator/value)
+        return collect($this->builder->wheres)->reduce(function ($builder, $where) {
+            if (is_array($where) && isset($where['field'])) {
+                $operator = $where['operator'] ?? '=';
+                return $builder->where($where['field'], $operator, $where['value']);
+            }
+            return $builder;
         }, $builder);
     }
 


### PR DESCRIPTION
## Summary
- Fix `handleSoftDeletes()` to work with Scout 11 wheres format (array of `[field, operator, value]` arrays instead of associative `field => value`)
- Fix `applyWheres()` to extract field, operator, value from Scout 11 format and pass operator to query builder
- PR #382 added the Scout 11 composer constraint but did not update the engine code for the breaking API change

## Context
Scout 11 changed `Builder->wheres` from:
```php
// Scout 10
["field" => "value"]

// Scout 11
[["field" => "age", "operator" => ">", "value" => 30]]
```

Without this fix, soft delete handling and where clause application will break on Scout 11.