### PR TITLE
fix: avoid infinite recursion in extend closure on Laravel 13

### DIFF
--- a/src/TNTSearchScoutServiceProvider.php
+++ b/src/TNTSearchScoutServiceProvider.php
@@ -29,8 +29,14 @@ class TNTSearchScoutServiceProvider extends ServiceProvider
             $tnt->setDatabaseHandle(app('db')->connection()->getPdo());
             $tnt->engine->maxDocs = config('scout.tntsearch.maxDocs', 500);
 
-            $this->setFuzziness($tnt);
-            $this->setAsYouType($tnt);
+            // Call via the fully-qualified class. Laravel 13's Manager::extend rebinds
+            // the closure's $this AND its scope to the Manager, so $this->setFuzziness()
+            // would proxy through Manager::__call -> $this->driver()->setFuzziness(...),
+            // which recursively invokes this same closure and exhausts memory.
+            // self::setFuzziness() falls into the same trap because PHP resolves it via
+            // the closure's rebound scope.
+            TNTSearchScoutServiceProvider::setFuzziness($tnt);
+            TNTSearchScoutServiceProvider::setAsYouType($tnt);
 
             return new TNTSearchEngine($tnt);
         });
@@ -48,7 +54,7 @@ class TNTSearchScoutServiceProvider extends ServiceProvider
         });
     }
 
-    protected function setFuzziness($tnt)
+    public static function setFuzziness($tnt)
     {
         $tnt->setFuzziness(config('scout.tntsearch.fuzziness', $tnt->getFuzziness()));
         $tnt->setFuzzyDistance(config('scout.tntsearch.fuzzy.distance', $tnt->getFuzzyDistance()));
@@ -57,7 +63,7 @@ class TNTSearchScoutServiceProvider extends ServiceProvider
         $tnt->setFuzzyNoLimit(config('scout.tntsearch.fuzzy.no_limit', $tnt->getFuzzyNoLimit()));
     }
 
-    protected function setAsYouType($tnt)
+    public static function setAsYouType($tnt)
     {
         $tnt->setAsYouType(config('scout.tntsearch.asYouType', $tnt->getAsYouType()));
     }


### PR DESCRIPTION
## Summary

Fixes #384 (and is what's killing every user reporting the silent OOM / no-response symptom in that thread on a Laravel 13 upgrade).

Laravel 13 added [`Illuminate\Support\RebindsCallbacksToSelf`](https://github.com/laravel/framework/blob/13.x/src/Illuminate/Support/RebindsCallbacksToSelf.php) and now [`Manager::extend`](https://github.com/laravel/framework/blob/13.x/src/Illuminate/Support/Manager.php) calls `bindCallbackToSelf` on the closure before storing it:

```php
public function extend($driver, Closure $callback)
{
    $callback = $this->bindCallbackToSelf($callback) ?? throw new RuntimeException(...);
    $this->customCreators[$driver] = $callback;
}
```

That rebinds **both** the closure's `$this` and its scope to the Manager instance via `Closure::bind($this, static::class)`.

`TNTSearchScoutServiceProvider::boot()` registers an extend closure that calls `$this->setFuzziness($tnt)` and `$this->setAsYouType($tnt)`. After the rebind:

- `$this` inside the closure is now the `EngineManager`, not the service provider.
- `EngineManager` does not define `setFuzziness` / `setAsYouType`.
- PHP routes the call through `Illuminate\Support\Manager::__call`, which proxies any unknown method to `$this->driver()->$method(...)`.
- `$this->driver()` resolves the default driver — which is `tntsearch` for anyone affected.
- That re-invokes this same extend closure.
- Each iteration allocates a fresh `TNTSearch` plus all the config-resolution intermediates (~6 KB), and never unwinds. Memory exhausts.

The reason it manifests as "no response, no logs, no output" (per #384) is that macOS / the kernel kills the process by OOM signal before PHP's shutdown handlers fire, so no fatal-error notice is written. Bumping `memory_limit` just moves the wall further out.

## Fix

Call the helpers via the fully-qualified class name and make them `public static`:

```diff
-            $this->setFuzziness($tnt);
-            $this->setAsYouType($tnt);
+            TNTSearchScoutServiceProvider::setFuzziness($tnt);
+            TNTSearchScoutServiceProvider::setAsYouType($tnt);

-    protected function setFuzziness($tnt)
+    public static function setFuzziness($tnt)

-    protected function setAsYouType($tnt)
+    public static function setAsYouType($tnt)
```

Why not `self::` — PHP resolves `self::` through the closure's rebound scope (the Manager), where the lookup falls back to `__call` the same way. The FQN sidesteps the rebind entirely. `public` is required because protected calls from a foreign scope (`Laravel\Scout\EngineManager` after the rebind) are rejected.

The helpers don't reference `$this` or `static::`, so the static signature is also semantically correct — they're pure config readers.

## Repro

Any Searchable model save with `SCOUT_DRIVER=tntsearch` on Laravel 13 reproduces. Minimum reproduction (no model needed):

```php
app(\Laravel\Scout\EngineManager::class)->engine('tntsearch');
```

Run with the default 512 M `memory_limit` → process gets killed (exit 255, no PHP fatal printed). Run under `php -d memory_limit=2G` and you'll see the eventual `PHP Fatal error: Allowed memory size exhausted in TNTSearch.php:33` (the spot of the last successful intermediate allocation) — not the actual loop site.

## After the fix

- Same minimal repro: closure invoked once, `TNTSearchEngine` returned, ~3 MB total memory delta.
- Full HTTP path on a Laravel 13 + Scout 11 app: `Searchable::save()` no longer OOMs.

## Backward compatibility

- `setFuzziness` and `setAsYouType` were `protected`, so no external subclass could call them anyway; widening to `public` is a strict relaxation.
- They had no `$this` access, so making them static doesn't change any caller's semantics — and there were no internal callers besides the closure.
- Older Laravel/Scout versions never rebound the closure, so the FQN call is also fine there (it was always semantically equivalent to `$this->`).
